### PR TITLE
Remove `z-register` requirement for the save position option

### DIFF
--- a/doc/multichange.txt
+++ b/doc/multichange.txt
@@ -136,17 +136,14 @@ Set to an empty string to avoid setting any mapping (you can still use the
 
                                                    *g:multichange_save_position*
 >
-    let g:multichange_save_position = 1
+    let g:multichange_save_position = 0
 <
-Default value: 0
+Default value: 1
 
 Setting this to 1 will make the plugin save and restore position after
 starting multi mode. This means that if you start multichange in a particular
-area with a text object, the cursor will not move.
-
-Note, however, that this clobbers the "z" register, which is why it's not the
-default.
-
+area with a text object, the cursor will not move. If set to 0, the cursor
+moves to the start of the text object, similar to the yank operation.
 
                                                     *g:multichange_show_match_count*
 >

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -24,14 +24,21 @@ endif
 
 command! -nargs=0 -count=0 Multichange call multichange#Setup(<count>)
 
+function! s:maybe_save_position()
+  if g:multichange_save_position
+    let s:memo_position = getpos('.')
+  endif
+endfunction
+
 function! s:MultichangeMotion(_motion_type)
+  let g:Multichange_memo_position = getpos(".")
   call setpos("'<", getpos("'["))
   call setpos("'>", getpos("']"))
 
   call multichange#Setup(1)
 
   if g:multichange_save_position
-    call setpos('.', g:Multichange_memo_position)
+    call setpos('.', s:memo_position)
     redraw
   endif
 endfunction
@@ -41,12 +48,7 @@ if g:multichange_mapping != '' && g:multichange_motion_mapping != ''
 endif
 
 if g:multichange_mapping != ''
-  if g:multichange_save_position
-    exe 'nnoremap <silent> '.g:multichange_mapping.' :let g:Multichange_memo_position = getpos(".") \| set opfunc=<SID>MultichangeMotion<cr>g@'
-  else
-    exe 'nnoremap <silent> '.g:multichange_mapping.' :set opfunc=<SID>MultichangeMotion<cr>g@'
-  endif
-
+  exe 'nnoremap <silent> '.g:multichange_mapping.' :call <SID>maybe_save_position() \| set opfunc=<SID>MultichangeMotion<cr>g@'
   exe 'xnoremap <silent> '.g:multichange_mapping.' :Multichange<cr>'
 endif
 

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -24,10 +24,8 @@ endif
 
 command! -nargs=0 -count=0 Multichange call multichange#Setup(<count>)
 
-function! s:maybe_save_position()
-  if g:multichange_save_position
-    let s:memo_position = getpos('.')
-  endif
+function! s:save_position()
+  let s:memo_position = getpos('.')
 endfunction
 
 function! s:MultichangeMotion(_motion_type)
@@ -48,7 +46,7 @@ if g:multichange_mapping != '' && g:multichange_motion_mapping != ''
 endif
 
 if g:multichange_mapping != ''
-  exe 'nnoremap <silent> '.g:multichange_mapping.' :call <SID>maybe_save_position() \| set opfunc=<SID>MultichangeMotion<cr>g@'
+  exe 'nnoremap <silent> '.g:multichange_mapping.' :call <SID>save_position() \| set opfunc=<SID>MultichangeMotion<cr>g@'
   exe 'xnoremap <silent> '.g:multichange_mapping.' :Multichange<cr>'
 endif
 

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -31,21 +31,18 @@ function! s:MultichangeMotion(_motion_type)
   call multichange#Setup(1)
 
   if g:multichange_save_position
-    normal! `z
+    call setpos('.', g:Multichange_memo_position)
+    redraw
   endif
 endfunction
 
 if g:multichange_mapping != '' && g:multichange_motion_mapping != ''
-  if g:multichange_save_position
-    exe 'nnoremap <silent> '.g:multichange_mapping.g:multichange_motion_mapping.' mz:Multichange<cr>`z'
-  else
     exe 'nnoremap <silent> '.g:multichange_mapping.g:multichange_motion_mapping.' :Multichange<cr>'
-  endif
 endif
 
 if g:multichange_mapping != ''
   if g:multichange_save_position
-    exe 'nnoremap <silent> '.g:multichange_mapping.' mz:set opfunc=<SID>MultichangeMotion<cr>g@'
+    exe 'nnoremap <silent> '.g:multichange_mapping.' :let g:Multichange_memo_position = getpos(".") \| set opfunc=<SID>MultichangeMotion<cr>g@'
   else
     exe 'nnoremap <silent> '.g:multichange_mapping.' :set opfunc=<SID>MultichangeMotion<cr>g@'
   endif

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -41,7 +41,7 @@ function! s:MultichangeMotion(_motion_type)
 endfunction
 
 if g:multichange_mapping != '' && g:multichange_motion_mapping != ''
-    exe 'nnoremap <silent> '.g:multichange_mapping.g:multichange_motion_mapping.' :Multichange<cr>'
+  exe 'nnoremap <silent> '.g:multichange_mapping.g:multichange_motion_mapping.' :Multichange<cr>'
 endif
 
 if g:multichange_mapping != ''

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -15,7 +15,7 @@ if !exists('g:multichange_motion_mapping')
 endif
 
 if !exists('g:multichange_save_position')
-  let g:multichange_save_position = 0
+  let g:multichange_save_position = 1
 endif
 
 if !exists('g:multichange_show_match_count')

--- a/plugin/multichange.vim
+++ b/plugin/multichange.vim
@@ -29,7 +29,6 @@ function! s:save_position()
 endfunction
 
 function! s:MultichangeMotion(_motion_type)
-  let g:Multichange_memo_position = getpos(".")
   call setpos("'<", getpos("'["))
   call setpos("'>", getpos("']"))
 


### PR DESCRIPTION
This pull request also changes the default value of the setting,
so that it saves position by default.

My motivation with this was mainly to get rid of the multichange
configuration in my vimrc, which is just one line.

If you think it's not desireable to change the default value of
the option, I can change this pull request.